### PR TITLE
feat: Add optional callback function to prometheus alerts

### DIFF
--- a/.changeset/nine-jeans-pump.md
+++ b/.changeset/nine-jeans-pump.md
@@ -1,0 +1,21 @@
+---
+'@roadiehq/backstage-plugin-prometheus': minor
+---
+
+Users can now add a callback to an `EntityPrometheusAlertCard` component. The component with callback can look like this:
+
+```typescript
+<EntityPrometheusAlertCard onRowClick={callbackFunction} />
+```
+
+And `callbackFunction` can have the following definition:
+
+```typescript
+const callbackFunction = (arg: Alerts) => {
+  ...
+};
+```
+
+Where the `Alerts` type is a user-defined type to more easily parse JSON definition (`any` type can also be used). This callback is optional; if not supplied, tables in the row are not clickable.
+
+This change modifies `PrometheusAlertStatus`, which adds `onRowClick` event to a `Table` component.

--- a/plugins/frontend/backstage-plugin-prometheus/README.md
+++ b/plugins/frontend/backstage-plugin-prometheus/README.md
@@ -191,6 +191,25 @@ prometheus:
       proxyPath: /prometheusTeamB/api
 ```
 
+## Using callback with `EntityPrometheusAlertCard`
+
+You can add callbacks that will be executed when the user clicks on a row in the table of the `EntityPrometheusAlertCard` component. This callback is optional, and the rows become clickable only when the callback is supplied. The callback function is also provided with data of type JSON. It contains the information from the row of the table.
+The component with callback can look like this:
+
+```typescript
+<EntityPrometheusAlertCard onRowClick={callbackFunction} />
+```
+
+Where `callbackFunction` can have the following definition:
+
+```typescript
+const callbackFunction = (arg: Alerts) => {
+  ...
+};
+```
+
+`Alerts` is a custom type you can define to easily parse JSON (or you can use `any` type).
+
 ## Links
 
 - [Backstage](https://backstage.io)

--- a/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertEntityWrapper.test.tsx
+++ b/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertEntityWrapper.test.tsx
@@ -94,4 +94,24 @@ describe('PrometheusAlertEntityWrapper', () => {
     expect(await rendered.findByText('Prometheus Alerts')).toBeInTheDocument();
     expect(await rendered.findByText('firing')).toBeInTheDocument();
   });
+
+  it('should render compontent with clickable rows', async () => {
+    const dummyCallback = jest.fn();
+    const rendered = render(
+      <ThemeProvider theme={lightTheme}>
+        <TestApiProvider apis={apis}>
+          <EntityProvider entity={entityMock}>
+            <PrometheusAlertEntityWrapper onRowClick={dummyCallback} />
+          </EntityProvider>
+        </TestApiProvider>
+      </ThemeProvider>,
+    );
+
+    const cell = await rendered.findByText('firing');
+    const row = await cell.closest('tr');
+    expect(cell).toBeInTheDocument();
+    expect(row).toBeInTheDocument();
+    expect(row?.onclick).toBeTruthy();
+    expect(row).toHaveStyle('cursor: pointer');
+  });
 });

--- a/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertEntityWrapper.tsx
+++ b/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertEntityWrapper.tsx
@@ -22,8 +22,13 @@ import {
   PROMETHEUS_ALERT_ANNOTATION,
 } from '../util';
 import { PrometheusAlertStatus } from './PrometheusAlertStatus';
+import { OnRowClick } from '../../types';
 
-export const PrometheusAlertEntityWrapper = () => {
+export const PrometheusAlertEntityWrapper = ({
+  onRowClick,
+}: {
+  onRowClick?: OnRowClick;
+}) => {
   const { entity } = useEntity();
   const alertContent = isPrometheusAlertAvailable(entity);
   if (!alertContent) {
@@ -36,8 +41,8 @@ export const PrometheusAlertEntityWrapper = () => {
     : [];
 
   return alerts.length > 0 && alerts[0] === 'all' ? (
-    <PrometheusAlertStatus alerts="all" />
+    <PrometheusAlertStatus alerts="all" onRowClick={onRowClick} />
   ) : (
-    <PrometheusAlertStatus alerts={alerts} />
+    <PrometheusAlertStatus alerts={alerts} onRowClick={onRowClick} />
   );
 };

--- a/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertStatus.tsx
+++ b/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertStatus.tsx
@@ -26,10 +26,11 @@ import {
   TableColumn,
 } from '@backstage/core-components';
 import { Chip, Tooltip, makeStyles } from '@material-ui/core';
+// eslint-disable-next-line
 import Alert from '@material-ui/lab/Alert';
 import { DateTime } from 'luxon';
 import { useAlerts } from '../../hooks/usePrometheus';
-import { PrometheusDisplayableAlert } from '../../types';
+import { OnRowClick, PrometheusDisplayableAlert } from '../../types';
 
 export default {
   title: 'Data Display/Status',
@@ -131,8 +132,10 @@ const columns: TableColumn<PrometheusDisplayableAlert>[] = [
 
 export const PrometheusAlertStatus = ({
   alerts,
+  onRowClick,
 }: {
   alerts: string[] | 'all';
+  onRowClick?: OnRowClick;
 }) => {
   const { error, loading, displayableAlerts } = useAlerts(alerts);
   if (loading) {
@@ -149,6 +152,9 @@ export const PrometheusAlertStatus = ({
             paging: false,
             toolbar: false,
           }}
+          onRowClick={
+            onRowClick ? (_, rowData) => onRowClick(rowData!) : undefined
+          }
           data={displayableAlerts}
           columns={columns}
         />

--- a/plugins/frontend/backstage-plugin-prometheus/src/types.ts
+++ b/plugins/frontend/backstage-plugin-prometheus/src/types.ts
@@ -79,3 +79,5 @@ export type PrometheusRuleResponse = {
   };
   status: 'success' | 'error';
 };
+
+export type OnRowClick = (arg: PrometheusDisplayableAlert) => void;


### PR DESCRIPTION
This PR introduces option in Prometheus plugin to specify a callback function in `EntityPrometheusAlertCard`. This callback is entirely optional. When specified rows become clickable and Plugin returns on click `PrometheusDisplayableAlert` data, which contain all the information which we can find in the row.
Example here:
![image](https://user-images.githubusercontent.com/47832967/217505059-abb9cf1a-35d7-4d4c-b043-d879f0234456.png)
Without callback specified:
![image](https://user-images.githubusercontent.com/47832967/217505140-ff7446a7-2e95-4312-8e7b-0579767b64d9.png)

Callback function can look as following
```ts
const callbackFun = (arg: PrometheusDisplayableAlert | undefined) => {
  ...
};
```
Where `PrometheusDisplayableAlert` is user defined or if user does not need to parse data from 
the table he can also supply just `any` and he can use this callback function.
Callback is only usable with `EntityPrometheusAlertCard` not with `EntityPrometheusContent`, because I did not want to introduce additional complexity to code. 
